### PR TITLE
PR: add multiple playlists at stream creation

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -971,11 +971,12 @@ class DateFormatter {
  */
 class StreamManager {
   // TODO: Make all of these static constants configurable.
-  static PLAYLIST_ID = "PL-sPk2tbAU2OVb91U_ij-3uHkSjJR2N--";
-  static PLAYLIST_ID_STANDARD = "PL-sPk2tbAU2MrOKm0AlBSqSVeZsK1xanp";
-  static PLAYLIST_ID_ALL_PREACHERS = "PL-sPk2tbAU2PRg6JjO47vYbI3h4oLRLYf";
-  static PLAYLIST_ID_CURR_SEASON = "PL-sPk2tbAU2Pii7Tc6fPwUGboZIpP3MYj";
-  static ALL_PLAYLIST_IDS = [this.PLAYLIST_ID, this.PLAYLIST_ID_STANDARD, this.PLAYLIST_ID_ALL_PREACHERS, this.PLAYLIST_ID_CURR_SEASON];
+  static ALL_PLAYLIST_IDS = [
+    "PL-sPk2tbAU2OVb91U_ij-3uHkSjJR2N--", // Standard Playlist
+    "PL-sPk2tbAU2MrOKm0AlBSqSVeZsK1xanp", // New Standard Playlist
+    "PL-sPk2tbAU2PRg6JjO47vYbI3h4oLRLYf", // All Preachers Playlist
+    "PL-sPk2tbAU2Pii7Tc6fPwUGboZIpP3MYj" // Current Season Playlist
+  ];
   static PREACHER_NOTE_CATEGORY = "Spreker";
   static THEME_NOTE_CATEGORY = "Thema";
   static DESCRIPTION_TEMPLATE = [


### PR DESCRIPTION
Als het goed is zou dit moeten werken. Ik heb nu ook even alle playlists er los instaan, maar deze zouden ook net zo goed in 1 regel in de array meteen kunnen, ligt eraan wat je duidelijker vind, dit kan bijvoorbeeld ook:
```
static ALL_PLAYLIST_IDS = [
  "PL-sPk2tbAU2OVb91U_ij-3uHkSjJR2N--", // Standard Playlist
  "PL-sPk2tbAU2MrOKm0AlBSqSVeZsK1xanp", // New Standard Playlist
  "PL-sPk2tbAU2PRg6JjO47vYbI3h4oLRLYf", // All Preachers Playlist
  "PL-sPk2tbAU2Pii7Tc6fPwUGboZIpP3MYj" // Current Season Playlist
];
```

Ook bij de forEach is het vooral wat jij makkelijker vind, heb dit gewoon er ff snel zo ingezet en volgens mij zou dit moeten werken, maar kijk maar.

Mocht je vragen hebben kan je natuurlijk altijd appen, of eventueel dat we dit donderdag kort doornemen kan natuurlijk ook!